### PR TITLE
Remove strict Golang version dependency

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/cloudfoundry-samples/pong_matcher_go",
-	"GoVersion": "go1.5.1",
+	"GoVersion": "go1.5",
 	"Deps": [
 		{
 			"ImportPath": "github.com/coopernurse/gorp",


### PR DESCRIPTION
To allow the application to stage with newer Buildpacks as older versions of Go are removed from support.

tagging @animatedmax 